### PR TITLE
Use bracket accessor syntax for annotations

### DIFF
--- a/lib/fatigue_check.js
+++ b/lib/fatigue_check.js
@@ -9,26 +9,22 @@ function fatigue_check(event) {
     // Use the above variable name with the check annotations fatigue_check/
     // (e.g. fatigue_check/occurrences) to override the defaults above
 
-    // Slashes make for easier reading, but need to be converted here to
-    // access the objects
-    var event_no_slashes = JSON.parse(JSON.stringify(event).replace(/\//g,"_"));
-
     // Check annotations first
     try {
         if (event.check.hasOwnProperty("annotations")) {
             if (event.check.annotations.hasOwnProperty("fatigue_check/occurrences")) {
-                occurrences = parseInt(event_no_slashes.check.annotations.fatigue_check_occurrences, 10);
+                occurrences = parseInt(event.check.annotations["fatigue_check/occurrences"], 10);
             }
             if (event.check.annotations.hasOwnProperty("fatigue_check/interval")) {
-                interval = parseInt(event_no_slashes.check.annotations.fatigue_check_interval, 10);
+                interval = parseInt(event.check.annotations["fatigue_check/interval"], 10);
             }
             if (event.check.annotations.hasOwnProperty("fatigue_check/allow_resolution")) {
                 // anything other than explicitly false == true
-                allow_resolution = !(/false/i).test(event_no_slashes.check.annotations.fatigue_check_allow_resolution);
+                allow_resolution = !(/false/i).test(event.check.annotations["fatigue_check/allow_resolution"]);
             }
             if (event.check.annotations.hasOwnProperty("fatigue_check/suppress_flapping")) {
                 // anything other than explicitly false == true
-                suppress_flapping = !(/false/i).test(event_no_slashes.check.annotations.fatigue_check_suppress_flapping);
+                suppress_flapping = !(/false/i).test(event.check.annotations["fatigue_check/suppress_flapping"]);
             }
         }
     }
@@ -43,18 +39,18 @@ function fatigue_check(event) {
     try {
         if (event.entity.hasOwnProperty("annotations")) {
             if (event.entity.annotations.hasOwnProperty("fatigue_check/occurrences")) {
-                occurrences = parseInt(event_no_slashes.entity.annotations.fatigue_check_occurrences, 10);
+                occurrences = parseInt(event.entity.annotations["fatigue_check/occurrences"], 10);
             }
             if (event.entity.annotations.hasOwnProperty("fatigue_check/interval")) {
-                interval = parseInt(event_no_slashes.entity.annotations.fatigue_check_interval, 10);
+                interval = parseInt(event.entity.annotations["fatigue_check/interval"], 10);
             }
             if (event.entity.annotations.hasOwnProperty("fatigue_check/allow_resolution")) {
                 // anything other than explicitly false == true
-                allow_resolution = !(/false/i).test(event_no_slashes.entity.annotations.fatigue_check_allow_resolution);
+                allow_resolution = !(/false/i).test(event.entity.annotations["fatigue_check/allow_resolution"]);
             }
             if (event.entity.annotations.hasOwnProperty("fatigue_check/suppress_flapping")) {
                 // anything other than explicitly false == true
-                suppress_flapping = !(/false/i).test(event_no_slashes.entity.annotations.fatigue_check_suppress_flapping);
+                suppress_flapping = !(/false/i).test(event.entity.annotations["fatigue_check/suppress_flapping"]);
             }
         }
     }


### PR DESCRIPTION
Avoids the stringify/replace/parse dance.